### PR TITLE
Fixed iteration of vehicles from API.

### DIFF
--- a/jlrpy.py
+++ b/jlrpy.py
@@ -38,7 +38,7 @@ class Connection(object):
 
         self.vehicles = []
         try:
-            for v in self.get_vehicles(self.head):
+            for v in self.get_vehicles(self.head)['vehicles']:
                 self.vehicles.append(v['vin'])
         except TypeError:
             print("[-] No vehicles associated with this account")


### PR DESCRIPTION
When iterating the dictionary of vehicles returned by the server we need to specify the `vehicles` index.