### PR TITLE
Implemented preconditioning controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,8 @@ c.vehicles[0].get_wakeup_time()
 c.vehicles[0].honk_blink()
 # Get current position of vehicle
 c.vehicles[0].get_position()
+# Start preconditioning at 21.0C
+c.vehicles[0].preconditioning_start("210")
+# Stop preconditioning
+c.vehicles[0].preconditioning_stop()
 ```

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -227,15 +227,27 @@ class Vehicle(dict):
 
     def climate_start(self, target_temp):
         """Start pre-conditioning for specified temperature (celsius)"""
+        service_parameters = [{"key": "PRECONDITIONING",
+                                          "value": "START"},
+                                         {"key": "TARGET_TEMPERATURE_CELSIUS",
+                                          "value": "%s" % target_temp}]
+        return self.preconditioning_control(service_parameters)
+
+    def climate_stop(self):
+        """Stop climate preconditioning"""
+        service_parameters = [{"key": "PRECONDITIONING",
+                               "value": "STOP"}]
+        return self.preconditioning_control(service_parameters)
+
+    def preconditioning_control(self, service_parameters):
+        """Control the climate preconditioning"""
         headers = self.connection.head.copy()
         headers["Accept"] = "application/vnd.wirelesscar.ngtp.if9.ServiceStatus-v5+json"
         headers["Content-Type"] = "application/vnd.wirelesscar.ngtp.if9.PhevService-v1+json; charset=utf"
 
         ecc_data = self.authenticate_ecc()
-        ecc_data['serviceParameters'] = [{"key": "PRECONDITIONING",
-                                          "value": "START"},
-                                         {"key": "TARGET_TEMPERATURE_CELSIUS",
-                                          "value": "%s" % target_temp}]
+        ecc_data['serviceParameters'] = service_parameters
+
         return self.post("preconditioning", headers, ecc_data)
 
     def __authenticate_vhs(self):

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -225,21 +225,21 @@ class Vehicle(dict):
         hblf_data = self.authenticate_hblf()
         return self.post("honkBlink", headers, hblf_data)
 
-    def climate_start(self, target_temp):
+    def preconditioning_start(self, target_temp):
         """Start pre-conditioning for specified temperature (celsius)"""
         service_parameters = [{"key": "PRECONDITIONING",
                                           "value": "START"},
                                          {"key": "TARGET_TEMPERATURE_CELSIUS",
                                           "value": "%s" % target_temp}]
-        return self.preconditioning_control(service_parameters)
+        return self._preconditioning_control(service_parameters)
 
-    def climate_stop(self):
+    def preconditioning_stop(self):
         """Stop climate preconditioning"""
         service_parameters = [{"key": "PRECONDITIONING",
                                "value": "STOP"}]
-        return self.preconditioning_control(service_parameters)
+        return self._preconditioning_control(service_parameters)
 
-    def preconditioning_control(self, service_parameters):
+    def _preconditioning_control(self, service_parameters):
         """Control the climate preconditioning"""
         headers = self.connection.head.copy()
         headers["Accept"] = "application/vnd.wirelesscar.ngtp.if9.ServiceStatus-v5+json"


### PR DESCRIPTION
Implemented the ability to start and stop climate preconditioning. 

To start climate preconditioning you have to pass the desired target temperature (in Celsius) without the decimal sign. For example, if you want to precondition to 21.0c you would call:

`c.vehicles[0].preconditioning_start("210")`

Preconditioning can be stopped with

`c.vehicles[0].preconditioning_stop()`

closes #16 