### PR TITLE
added function to enable service/transport mode for a specified time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,8 @@ schedule = {"friday":false,"monday":true,"saturday":false,"sunday":false,"thursd
 v.add_repeated_departure_timer(10, 20, 30, schedule)
 # Set wakeup timer (epoch millis)
 v.set_wakeup_time(1547845200000)
+# Enable service mode (requires personal PIN)
+`v.enable_service_mode("1234", 1547551847000)`
+# Enable transport mode (requires personal PIN)
+`v.enable_transport_mode("1234", 1547551847000)`
 ```

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -337,13 +337,21 @@ class Vehicle(dict):
 
     def enable_service_mode(self, pin, expiration_time):
         """Enable service mode. Will disable at the specified time (epoch millis)"""
+        self._disable_theft_alarm(pin, expiration_time, "protectionStrategy_serviceMode")
+
+    def enable_transport_mode(self, pin, expiration_time):
+        """Enable transport mode. Will be disabled at the specified time (epoch millis)"""
+        self._disable_theft_alarm(pin, expiration_time, "protectionStrategy_transportMode")
+
+    def _disable_theft_alarm(self, pin, expiration_time, mode):
+        """Enable transport mode or service mode"""
         headers = self.connection.head.copy()
         headers["Accept"] = "application/vnd.wirelesscar.ngtp.if9.ServiceStatus-v4+json"
         headers["Content-Type"] = "application/vnd.wirelesscar.ngtp.if9.StartServiceConfiguration-v3+json; charset=utf-8"
 
         prov_data = self.authenticate_prov(pin)
 
-        prov_data["serviceCommand"] = "protectionStrategy_serviceMode"
+        prov_data["serviceCommand"] = mode
         prov_data["startTime"] = None
         prov_data["endTime"] = expiration_time
 

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -334,6 +334,20 @@ class Vehicle(dict):
 
         return self.post("swu", headers, swu_data)
 
+    def enable_service_mode(self, pin, expiration_time):
+        """Enable service mode. Will disable at the specified time (epoch millis)"""
+        headers = self.connection.head.copy()
+        headers["Accept"] = "application/vnd.wirelesscar.ngtp.if9.ServiceStatus-v4+json"
+        headers["Content-Type"] = "application/vnd.wirelesscar.ngtp.if9.StartServiceConfiguration-v3+json; charset=utf-8"
+
+        prov_data = self.authenticate_prov(pin)
+
+        prov_data["serviceCommand"] = "protectionStrategy_serviceMode"
+        prov_data["startTime"] = None
+        prov_data["endTime"] = expiration_time
+
+        return self.post("prov", headers, prov_data)
+
     def _authenticate_vhs(self):
         """Authenticate to vhs and get token"""
         return self._authenticate_empty_pin_protected_service("VHS")
@@ -380,6 +394,10 @@ class Vehicle(dict):
     def authenticate_rdu(self, pin):
         """Authenticate to rdu"""
         return self._authenticate_pin_protected_service(pin, "RDU")
+
+    def authenticate_prov(self, pin):
+        """Authenticate to PROV service"""
+        return self._authenticate_pin_protected_service(pin, "PROV")
 
     def _authenticate_pin_protected_service(self, pin, service_name):
         """Authenticate to specified service with the provided PIN"""


### PR DESCRIPTION
Added required `PROV` service authentication as well. 

Call `enable_service_mode(pin, expiration_time)` or `enable_transport_mode(pin, expiration_time)` on a vehicle object to enable. Requires personal PIN.

Example: `v.enable_service_mode("1234", 1547551847000)` or `v.enable_transport_mode("1234", 1547551847000)`