### PR TITLE
Added functions to specify max state of charge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ v.unlock()
 v.charging_start()
 # Stop charging
 v.charging_stop()
+# Set max soc at 80%
+v.set_max_soc(80)
+# Set max soc for current charging session to 90%
+v.set_one_off_max_soc(90)
 # Add single departure timer (index, year, month, day, hour, minute)
 v.add_departure_timer(10, 2019, 1, 30, 20, 30)
 # Delete a single departure timer index.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ v.unlock()
 v.charging_start()
 # Stop charging
 v.charging_stop()
-# Set max soc at 80%
+# Set max soc at 80% (Requires upcoming OTA update)
 v.set_max_soc(80)
-# Set max soc for current charging session to 90%
+# Set max soc for current charging session to 90% (Requires upcoming OTA update)
 v.set_one_off_max_soc(90)
 # Add single departure timer (index, year, month, day, hour, minute)
 v.add_departure_timer(10, 2019, 1, 30, 20, 30)

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -288,6 +288,20 @@ class Vehicle(dict):
 
         return self._charging_profile_control("serviceParameters", service_parameters)
 
+    def set_max_soc(self, max_charge_level):
+        """Set max state of charge in percentage"""
+        service_parameters = [{"key": "SET_PERMANENT_MAX_SOC",
+                               "value": max_charge_level}]
+
+        return self._charging_profile_control("serviceParameters", service_parameters)
+
+    def set_one_off_max_soc(self, max_charge_level):
+        """Set one off max state of charge in percentage"""
+        service_parameters = [{"key": "SET_ONE_OFF_MAX_SOC",
+                               "value": max_charge_level}]
+
+        return self._charging_profile_control("serviceParameters", service_parameters)
+
     def add_departure_timer(self, index, year, month, day, hour, minute):
         """Add a single departure timer with the specified index"""
         departure_timer_setting = {"timers": [


### PR DESCRIPTION
You can specify both permanent and one off max state of charge. A integer value indicating the desired max soc charge level needs to be passed to the associated function.

To set a max soc of 80% you would could do the following.

```python
v.set_max_soc(80)  # Set 80% max charge
v.set_one_off_max_soc(90)  # Set 90% max charge for the current charging session only
```