### PR TITLE
Implemented get_trip() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ v.get_status()
 v.get_subscription_packages()
 # Get trip data (last 1000 trips).
 v.get_trips()
+# Get data for a single trip (specified with trip id)
+v.get_trip(121655021)
 # Get vehicle health status
 v.get_health_status()
 # Get departure timers

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -195,6 +195,10 @@ class Vehicle(dict):
         """Get the last 1000 trips associated with vehicle"""
         return self.get('trips?count=1000', self.connection.head)
 
+    def get_trip(self, trip_id):
+        """Get info on a specific trip"""
+        return self.get('trips/%s/route?pageSize=1000&page=0' % trip_id, self.connection.head)
+
     def get_position(self):
         """Get current vehicle position"""
         return self.get('position', self.connection.head)


### PR DESCRIPTION
Retrieves information on a specific trip specified by the trip id.

The get_trips() function returns the full trip log. Each trip entry has a `id` identifier. Pass this identifier to the `get_trip()` function to get single trip data

Fixes #35 