### PR TITLE
Added missing `Accept` header in get_trips()

### DIFF
--- a/jlrpy.py
+++ b/jlrpy.py
@@ -216,6 +216,8 @@ class Vehicle(dict):
 
     def get_trips(self):
         """Get the last 1000 trips associated with vehicle"""
+        headers = self.connection.head.copy()
+        headers["Accept"] = "application/vnd.ngtp.org.triplist-v2+json"
         return self.get('trips?count=1000', self.connection.head)
 
     def get_trip(self, trip_id):


### PR DESCRIPTION
The get_trips() method should include a special `Accept` header field in order to return the complete data set from the API. The function to retrieve data from a single trip does seemingly not require this but that could potentially be a bug in the Android app.

Fixes #44 