### PR TITLE
Use correct header object in get_trips()

### DIFF
--- a/jlrpy.py
+++ b/jlrpy.py
@@ -218,7 +218,7 @@ class Vehicle(dict):
         """Get the last 1000 trips associated with vehicle"""
         headers = self.connection.head.copy()
         headers["Accept"] = "application/vnd.ngtp.org.triplist-v2+json"
-        return self.get('trips?count=1000', self.connection.head)
+        return self.get('trips?count=1000', headers)
 
     def get_trip(self, trip_id):
         """Get info on a specific trip"""


### PR DESCRIPTION
When fixing the `Accept` header field value in `get_trips()` I forgot to use the updated header object when creating the request. This fixes that embarrasing mistake.