### PR TITLE
Remove 'uuid' and 'datetime' from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ardevd/jlrpy",
     py_modules=['jlrpy'],
-    install_requires=[
-        'uuid',
-        'datetime',
-    ],
+    install_requires=[],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
I believe `jlrpy` is using the standard library `datetime` and `uuid` rather than the PyPI packages of the same name [datetime](https://pypi.org/project/DateTime/) (from Zope) and [uuid](https://pypi.org/project/uuid/#history) (maybe the standard library module, last release 2006!). Therefore I've dropped them from `install_requires` here.