### PR TITLE
concatenate ev and core status lists to fix vehicle item retrieval

### DIFF
--- a/jlrpy.py
+++ b/jlrpy.py
@@ -219,7 +219,10 @@ class Vehicle(dict):
         result = self.get('status?includeInactive=true', headers)
 
         if key:
-            return {d['key']: d['value'] for d in result['vehicleStatus']}[key]
+            coreStatusList = result['vehicleStatus']['coreStatus']
+            evStatusList = result['vehicleStatus']['evStatus']
+            coreStatusList = coreStatusList + evStatusList
+            return {d['key']: d['value'] for d in coreStatusList}[key]
 
         return result
 
@@ -566,7 +569,7 @@ class Vehicle(dict):
         """Authenticate to vhs and get token"""
         return self._authenticate_empty_pin_protected_service("VHS")
 
-    def _authenticate_empty_pin_protected_service(self, service_name):    
+    def _authenticate_empty_pin_protected_service(self, service_name):
         return self._authenticate_service("", service_name)
 
     def authenticate_hblf(self):


### PR DESCRIPTION
The new vehicle status request version splits up core and ev status items in separate lists. Therefore, in order to lookup a given status value we need to concatenate the two lists. 