### PR TITLE
Update jlrpy.py

### DIFF
--- a/jlrpy.py
+++ b/jlrpy.py
@@ -224,6 +224,10 @@ class Vehicle(dict):
             coreStatusList = coreStatusList + evStatusList
             return {d['key']: d['value'] for d in coreStatusList}[key]
 
+        coreStatusList = result['vehicleStatus']['coreStatus']
+        evStatusList = result['vehicleStatus']['evStatus']
+        result['vehicleStatus'] = coreStatusList + evStatusList
+    
         return result
 
     def get_health_status(self):


### PR DESCRIPTION
Change to fix issue #81 

Jaguar changed the return structure from the get_status() call, this was fixed for specific key status requests in update #80, however the code sample examples/charge_offpeak.py uses the get_status() function with a null key, and this change updates the jlrpy code to maintain compatibility with the example code & return the structure it did prior to the new code from jaguar.