### PR TITLE
Change to fix issue #81  

### DIFF
--- a/examples/charge_offpeak.py
+++ b/examples/charge_offpeak.py
@@ -86,7 +86,10 @@ def check_soc():
 
     # getting health status forces a status update
     healthstatus = v.get_health_status()
-    status = { d['key'] : d['value'] for d in v.get_status()['vehicleStatus'] }
+    # get the vehicle status 
+    vehicleStatus = v.get_status()['vehicleStatus']
+    #we have a list of keys and values - we need to convert to a dict to make it more usable
+    status = { d['key'] : d['value'] for d in vehicleStatus }
 
     current_soc = int(status['EV_STATE_OF_CHARGE'])
     charging_status = status['EV_CHARGING_STATUS']

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -224,10 +224,6 @@ class Vehicle(dict):
             coreStatusList = coreStatusList + evStatusList
             return {d['key']: d['value'] for d in coreStatusList}[key]
 
-        coreStatusList = result['vehicleStatus']['coreStatus']
-        evStatusList = result['vehicleStatus']['evStatus']
-        result['vehicleStatus'] = coreStatusList + evStatusList
-    
         return result
 
     def get_health_status(self):

--- a/jlrpy.py
+++ b/jlrpy.py
@@ -224,6 +224,10 @@ class Vehicle(dict):
             coreStatusList = coreStatusList + evStatusList
             return {d['key']: d['value'] for d in coreStatusList}[key]
 
+        coreStatusList = result['vehicleStatus']['coreStatus']
+        evStatusList = result['vehicleStatus']['evStatus']
+        result['vehicleStatus'] = coreStatusList + evStatusList
+    
         return result
 
     def get_health_status(self):


### PR DESCRIPTION
the get_status() call in jlrpy when called with no key - returns  a new format, breaking charge_offpeak.py This works in parallel with change #80 

The change fixes charge_offpeak.py to allow it to get at the returned vehicle status by building a dict from the 'vehiclestatus' list. 